### PR TITLE
Bug fix Suggestions

### DIFF
--- a/src/org/violetlib/aqua/AquaLookAndFeel.java
+++ b/src/org/violetlib/aqua/AquaLookAndFeel.java
@@ -763,7 +763,9 @@ public class AquaLookAndFeel extends BasicLookAndFeel {
         table.putDefaults(defaults);
 
         int version = AquaUtils.getJavaVersion();
-        if (version < 900000) {
+
+		/* This is still needed in versions after 9 if you use a menu bar embedded in a window. */
+//         if (version < 900000) {
             // prior to Java 9, the platform UI is needed to support the screen menu bar
             // the following definitions allow the platform UI to paint a non-screen menu bar
             final Color menuBackgroundColor = new ColorUIResource(Color.white);
@@ -789,6 +791,8 @@ public class AquaLookAndFeel extends BasicLookAndFeel {
                     "MenuBar.selectedBackgroundPainter", NOTHING_BORDER,
             };
             table.putDefaults(menuBarDefaults);
+
+		if (version < 900000) {
             // In addition, the AquaLAF must be encouraged to load its native library
             try {
                 Class.forName("com.apple.laf.AquaNativeResources");

--- a/src/org/violetlib/aqua/AquaOverlayScrollPaneLayout.java
+++ b/src/org/violetlib/aqua/AquaOverlayScrollPaneLayout.java
@@ -59,7 +59,8 @@ public class AquaOverlayScrollPaneLayout extends ScrollPaneLayout implements UIR
 
     @Override
     public Dimension preferredLayoutSize(Container parent) {
-        sync(parent);
+    		//Calling sync here can cause a hang sometimes when using a JEditorPane
+        //sync(parent);
         return super.preferredLayoutSize(parent);
     }
 

--- a/src/org/violetlib/aqua/AquaUtils.java
+++ b/src/org/violetlib/aqua/AquaUtils.java
@@ -318,16 +318,18 @@ final public class AquaUtils {
      */
     public static @NotNull Rectangle getScreenBounds(@Nullable GraphicsConfiguration gc) {
         Rectangle bounds;
+		Insets insets;
         Toolkit toolkit = Toolkit.getDefaultToolkit();
         if (gc != null) {
             // If we have GraphicsConfiguration use it to get screen bounds
             bounds = gc.getBounds();
+            insets = toolkit.getScreenInsets(gc);
         } else {
             // If we don't have GraphicsConfiguration use primary screen
             bounds = new Rectangle(toolkit.getScreenSize());
+            insets = new Insets(0,0,0,0);
         }
 
-        Insets insets = toolkit.getScreenInsets(gc);
         int top = insets.top;
         int bottom = insets.bottom;
         int left = insets.left;

--- a/src/org/violetlib/aqua/fc/FileSystemTreeModel.java
+++ b/src/org/violetlib/aqua/fc/FileSystemTreeModel.java
@@ -142,14 +142,17 @@ public class FileSystemTreeModel implements TreeModel {
      * Removes all children from the root node.
      */
     private void clear() {
-        int[] removedIndices = new int[root.getChildCount()];
-        Object[] removedChildren = new Object[removedIndices.length];
-        for (int i = 0; i < removedIndices.length; i++) {
-            removedIndices[i] = i;
-            removedChildren[i] = root.getChildAt(0);
-            root.remove(0);
-        }
-        fireTreeNodesRemoved(FileSystemTreeModel.this, new Object[]{root}, removedIndices, removedChildren);
+    		int childCount = root.getChildCount();
+    		if (childCount > 0) {
+			int[] removedIndices = new int[childCount];
+			Object[] removedChildren = new Object[removedIndices.length];
+			for (int i = 0; i < removedIndices.length; i++) {
+				removedIndices[i] = i;
+				removedChildren[i] = root.getChildAt(0);
+				root.remove(0);
+			}
+			fireTreeNodesRemoved(FileSystemTreeModel.this, new Object[]{root}, removedIndices, removedChildren);
+		}
     }
 
     public void dispose() {

--- a/src/org/violetlib/aqua/fc/JBrowser.java
+++ b/src/org/violetlib/aqua/fc/JBrowser.java
@@ -2187,7 +2187,7 @@ public class JBrowser extends JComponent implements Scrollable {
                 int startIndex;
                 int end;
                 int offset = 0;
-                do {
+                while (start < indices.length) {
                     startIndex = indices[start];
                     for (end = start + 1; end < indices.length; end++) {
                         if (indices[end] != startIndex + end - start) {
@@ -2197,7 +2197,7 @@ public class JBrowser extends JComponent implements Scrollable {
                     fireIntervalRemoved(this, startIndex - offset, indices[end - 1] - offset);
                     offset += indices[end - 1] - startIndex + 1;
                     start = end;
-                } while (start < indices.length);
+                }
 
                 // RemovedChildren can't be selected.
                 if (selectionModel.getSelectionCount() > 0) {


### PR DESCRIPTION
Below are the bugs that would be fixed by this pull request:

* AquaLookAndFeel omitted some properties related to menubars in Java versions 9+ that were not needed for the screen menubar. They are needed for menubars embedded in an a JFrame, however, so they are no longer being excluded.
* Removed call to `sync(parent)` in `AquaOverlayScrollPanelLayout.preferredLayoutSize()`.  This was causing deadlocks in some cases when used with JEditorPane.
* Fixed NPE in AquaUtils.getScreenBounds when `gc` was null.
* Fixed NPE in `FileSystemTreeModel.clear()` that would occur if model was empty.
* Fixed IndexOutOfBoundsException in `JBrowser.treeNodesRemoved()` that would happen in cases where the event object didn't have have any items in the list of removed items.