### PR TITLE
Support for java.version with four sub versions

### DIFF
--- a/src/org/violetlib/aqua/AquaLookAndFeel.java
+++ b/src/org/violetlib/aqua/AquaLookAndFeel.java
@@ -763,7 +763,7 @@ public class AquaLookAndFeel extends BasicLookAndFeel {
         table.putDefaults(defaults);
 
         int version = AquaUtils.getJavaVersion();
-        if (version < 900000) {
+        if (version < 900000000) {
             // prior to Java 9, the platform UI is needed to support the screen menu bar
             // the following definitions allow the platform UI to paint a non-screen menu bar
             final Color menuBackgroundColor = new ColorUIResource(Color.white);
@@ -843,7 +843,7 @@ public class AquaLookAndFeel extends BasicLookAndFeel {
                 "PopupMenuUI", PKG_PREFIX + "AquaPopupMenuUI",
                 "TextAreaUI", PKG_PREFIX + "AquaTextAreaUI",
                 // prior to Java 9, the platform UI is needed to support the screen menu bar
-                "MenuBarUI", version >= 900000 ? PKG_PREFIX + "AquaMenuBarUI" : "com.apple.laf.AquaMenuBarUI",
+                "MenuBarUI", version >= 900000000 ? PKG_PREFIX + "AquaMenuBarUI" : "com.apple.laf.AquaMenuBarUI",
                 "FileChooserUI", PKG_PREFIX + "fc.AquaFileChooserUI",
                 "PasswordFieldUI", PKG_PREFIX + "AquaTextPasswordFieldUI",
                 "TableHeaderUI", PKG_PREFIX + "AquaTableHeaderUI",

--- a/src/org/violetlib/aqua/AquaUtils.java
+++ b/src/org/violetlib/aqua/AquaUtils.java
@@ -140,9 +140,9 @@ final public class AquaUtils {
         return javaVersion;
     }
 
-    private static int obtainJavaVersion()
+    public int obtainJavaVersion(String s)
     {
-        String s = System.getProperty("java.version");
+
         if (s.startsWith("1.")) {
             s = s.substring(2);
         }
@@ -158,7 +158,7 @@ final public class AquaUtils {
                 }
                 int n = Integer.parseInt(token);
                 ++tokenCount;
-                int limit = tokenCount < 3 ? 100 : 1000;
+                int limit = tokenCount < 4 ? 100 : 1000;
                 if (n < 0 || n >= limit) {
                     return 0;
                 }
@@ -168,13 +168,13 @@ final public class AquaUtils {
             return 0;
         }
 
-        while (tokenCount < 3) {
+        while (tokenCount < 4) {
             ++tokenCount;
             int limit = tokenCount < 3 ? 100 : 1000;
             version = version * limit;
         }
 
-        if (tokenCount != 3) {
+        if (tokenCount != 4) {
             return 0;
         }
         return version;

--- a/src/org/violetlib/aqua/JavaSupport.java
+++ b/src/org/violetlib/aqua/JavaSupport.java
@@ -140,7 +140,7 @@ public class JavaSupport {
     private static JavaSupportImpl findImpl() {
         int version = AquaUtils.getJavaVersion();
         String className;
-        if (version >= 900000) {
+        if (version >= 900000000) {
             className = "Java9Support";
         } else {
             className = "Java8Support";

--- a/src/org/violetlib/aqua/KeyWindowPatch.java
+++ b/src/org/violetlib/aqua/KeyWindowPatch.java
@@ -53,7 +53,7 @@ public class KeyWindowPatch
 
     private static Boolean computeIfNeeded() {
         int version = AquaUtils.getJavaVersion();
-        return version < 1100000;
+        return version < 1100000000;
     }
 
     private static void loadNativeSupport() {

--- a/src/org/violetlib/aqua/WindowStylePatch.java
+++ b/src/org/violetlib/aqua/WindowStylePatch.java
@@ -35,7 +35,7 @@ public class WindowStylePatch
 
     private static Boolean computeIfNeeded() {
         int version = AquaUtils.getJavaVersion();
-        return version < 1200000;
+        return version < 1200000000;
     }
 
     private static void loadNativeSupport() {


### PR DESCRIPTION
Hi,
this PR fixes #3 by increasing the maximum number of sub versions for `java.version` to four (ie. from `a` to `a.b.x.d`).

I saw the version is passed to a native function at `org/violetlib/aqua/AquaNativeSupport.java:176` but couldn't find any usages in the native code so I'm not sure this works.