### PR TITLE
Correct unicode character for ä in FileChooser.devices translation

### DIFF
--- a/resources/org/violetlib/aqua/Labels_de.properties
+++ b/resources/org/violetlib/aqua/Labels_de.properties
@@ -268,7 +268,7 @@ FileChooser.untitledFolderName=Neuer Ordner
 OptionPane.okButtonText=OK
 
 FileChooser.favorites=Favoriten
-FileChooser.devices=Ger\u00c4te
+FileChooser.devices=Ger\u00e4te
 FileChooser.places=Orte
 
 Filechooser.previewButton.text=Vorschau:


### PR DESCRIPTION
Fixes #5 