### PR TITLE
Support disabled colour in text components

### DIFF
--- a/src/org/violetlib/aqua/AquaColors.java
+++ b/src/org/violetlib/aqua/AquaColors.java
@@ -15,6 +15,7 @@ import javax.swing.text.JTextComponent;
 
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
+import org.violetlib.jnr.aqua.AquaUIPainter;
 
 import static org.violetlib.aqua.OSXSystemProperties.OSVersion;
 
@@ -528,6 +529,7 @@ public class AquaColors {
                                           @NotNull BasicContextualColors colors) {
 
         AppearanceContext selectedContext = context.withSelected(true);
+        AppearanceContext disabledContext = context.withState(AquaUIPainter.State.DISABLED);
 
         Color bg = editor.getBackground();
         if (!isPriority(bg)) {
@@ -556,7 +558,7 @@ public class AquaColors {
 
         Color dfg = editor.getDisabledTextColor();
         if (!isPriority(dfg)) {
-            editor.setDisabledTextColor(colors.getForeground(context));
+            editor.setDisabledTextColor(colors.getForeground(disabledContext));
         }
     }
 


### PR DESCRIPTION
Without this, `getDisabledTextColor()` on a text component returns the same colour as non-disabled.