### PR TITLE
table header: respect intercellSpacing for header cells

### DIFF
--- a/src/org/violetlib/aqua/AquaTableHeaderUI.java
+++ b/src/org/violetlib/aqua/AquaTableHeaderUI.java
@@ -304,8 +304,10 @@ public class AquaTableHeaderUI extends BasicTableHeaderUI implements AquaCompone
                 rendererComponent.setForeground(foreground);
             }
 
-            rendererPane.paintComponent(g, rendererComponent, header, cellRect.x, cellRect.y,
-                    cellRect.width, cellRect.height, true);
+            final Dimension intercellSpacing = header.getTable().getIntercellSpacing();
+
+            rendererPane.paintComponent(g, rendererComponent, header, cellRect.x + intercellSpacing.width / 2, cellRect.y,
+                    cellRect.width - intercellSpacing.width, cellRect.height, true);
 
             // Setting the foreground or background color of a DefaultTableCellRenderer makes that color the color
             // to use when the cell is not selected. So, if we installed a color, we should also remove it.


### PR DESCRIPTION
Currently table headers don't respect the intercell spacing set on the table, so with an intercell spacing of (say) 8, the header is 4px too far to the left, and if your header is right-aligned then it's 4px too far to the right.