### PR TITLE
Fix `ConcurrentModificationException` when firing `OSXSystemProperties` change events

### DIFF
--- a/src/org/violetlib/aqua/OSXSystemProperties.java
+++ b/src/org/violetlib/aqua/OSXSystemProperties.java
@@ -184,7 +184,7 @@ public class OSXSystemProperties {
             SwingUtilities.invokeLater(new Runnable() {
                 public void run() {
                     ChangeEvent event = new ChangeEvent(OSXSystemProperties.class);
-                    for (ChangeListener listener : changeListeners) {
+                    for (ChangeListener listener : new ArrayList<>(changeListeners)) {
                         listener.stateChanged(event);
                     }
                 }


### PR DESCRIPTION
Fixes #32 