### PR TITLE
avoid NPE when trying to getUI of null parent

### DIFF
--- a/src/org/violetlib/aqua/AquaCellBorder.java
+++ b/src/org/violetlib/aqua/AquaCellBorder.java
@@ -38,9 +38,11 @@ public class AquaCellBorder extends AbstractBorder implements UIResource {
             parent = parent.getParent();
         }
 
-        AquaViewStyleContainerUI ui = AquaUtils.getUI((JComponent) parent, AquaViewStyleContainerUI.class);
-        if (ui != null) {
-            return ui.isInset();
+        if (parent != null) {
+            AquaViewStyleContainerUI ui = AquaUtils.getUI((JComponent) parent, AquaViewStyleContainerUI.class);
+            if (ui != null) {
+                return ui.isInset();
+            }
         }
 
         Object o = c.getClientProperty(RENDERER_CONTAINER_KEY);


### PR DESCRIPTION
a component will have a null parent when used in a cell renderer, resulting in an NPE if you try to do something that calls this code on such a component, like setting a border: cellRenderer.setBorder -> getBorderInsets -> computerIsInset -> getUI(parent) -> NPE because of NotNull annotation.
