### PR TITLE
Treetable margins

### DIFF
--- a/src/org/violetlib/treetable/ui/BasicTreeTableUI.java
+++ b/src/org/violetlib/treetable/ui/BasicTreeTableUI.java
@@ -455,7 +455,7 @@ public class BasicTreeTableUI extends TreeTableUI {
         }
 
         treeTableCellRenderer.prepareForTree();
-        Graphics cg = g.create(x, 0, tree.getWidth(), tree.getHeight());
+        Graphics cg = g.create(x, tree.getY(), tree.getWidth(), tree.getHeight());
         try {
             cg.clipRect(clipX, 0, clipW, tree.getHeight());
             tree.paint(cg);

--- a/src/org/violetlib/treetable/ui/InternalTableWithMargins.java
+++ b/src/org/violetlib/treetable/ui/InternalTableWithMargins.java
@@ -96,6 +96,15 @@ public class InternalTableWithMargins
     }
 
     @Override
+    public int rowAtPoint(@NotNull Point point)
+    {
+        if (margin > 0 || verticalMargin > 0) {
+            point = new Point(point.x - margin, point.y - verticalMargin);
+        }
+        return super.rowAtPoint(point);
+    }
+
+    @Override
     public @NotNull Rectangle getCellRect(int row, int column, boolean includeSpacing)
     {
         Rectangle r = super.getCellRect(row, column, includeSpacing);


### PR DESCRIPTION
I observed these problems in the list view of the `JFileChooser`... clicking rows was off by the top margin, and drawing of the _tree_ part of the tree table was off by the top margin.

In `BasicTreeTableUI` I don't really understand the `clipX` calculation so I'm hoping that stays fine!