### PR TITLE
Hierarchy listener leak in `AquaComboBoxUI`

### DIFF
--- a/src/org/violetlib/aqua/AquaComboBoxUI.java
+++ b/src/org/violetlib/aqua/AquaComboBoxUI.java
@@ -178,6 +178,7 @@ public class AquaComboBoxUI extends BasicComboBoxUI
             ((AquaComboBoxPopup) popup).removeHierarchyListener(popupListener);
         }
         comboBox.removePropertyChangeListener(propertyChangeListener);
+        comboBox.removeHierarchyListener(hierarchyListener);
         hierarchyListener = null;
         AquaUtilControlSize.removeSizePropertyListener(comboBox);
         OSXSystemProperties.unregister(comboBox);


### PR DESCRIPTION
`uninstallListeners()` wasn't removing the hierarchy listener.