### PR TITLE
fix: quadratic scroll speed in smooth scrolling causes enormous jumps

### DIFF
--- a/src/org/violetlib/aqua/AquaScrollPaneUI.java
+++ b/src/org/violetlib/aqua/AquaScrollPaneUI.java
@@ -909,6 +909,6 @@ public class AquaScrollPaneUI extends BasicScrollPaneUI
     }
 
     public static double getUnitsToScroll(@NotNull MouseWheelEvent e, boolean isSmooth) {
-        return isSmooth ? e.getUnitsToScroll() * e.getPreciseWheelRotation() : e.getUnitsToScroll();
+        return isSmooth ? e.getScrollAmount() * e.getPreciseWheelRotation() : e.getUnitsToScroll();
     }
 }


### PR DESCRIPTION
The smooth scrolling path in `getUnitsToScroll(MouseWheelEvent e, boolean isSmooth)` used `e.getUnitsToScroll()` (which is `scrollAmount * wheelRotation`) multiplied by `e.getPreciseWheelRotation()` (which is ~`wheelRotation`). This squares the wheel rotation, causing scroll distance to grow quadratically with scroll speed rather than linearly.

Fix: use `e.getScrollAmount()` (the per-notch amount, typically 3) instead of `e.getUnitsToScroll()` so the rotation is only applied once via `getPreciseWheelRotation()`.